### PR TITLE
Templdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+ruller-dsl-feature-flag
+
+rules.go

--- a/README.md
+++ b/README.md
@@ -88,7 +88,13 @@ curl -X POST \
 
 ## Runtime parameters
 
-* The same as http://github.com/flaviostutz/ruller. Check documentation for details
+* The same as http://github.com/flaviostutz/ruller with the addition of `--templdir`:
+
+1. `--source`: a comma-separated list of `.json` files where `ruller-dsl-feature-flag` will read the rules from;
+2. `--target`: the path of the file where the Golang ruller engine will be generated;
+3. `--templdir`: the path where the template files can be found;
+4. `--log-level`: the level of logging `ruller-dsl-feature-flag` will output to STDOUT;
+5. `--condition-debug`: if present, the resulting Golang ruller engine will output debug info when processing feature flags;
 
 ## Feature selection language
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ curl -X POST \
 
 ## Development tips
 
+* Always explicitly define the `target` and `templdir` runtime parameters on development time:
+
+```sh
+go build
+./ruller-dsl-feature-flag --source <paths to rule json files> --target ./rules.go --templdir ./templates
+```
+
 * After closing a version
   * Tag the repository code
   * Check the autobuild on Dockerhub to see if all went well and that the new tag was created

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ func main() {
 	logLevel := flag.String("log-level", "info", "debug, info, warning or error")
 	source := flag.String("source", "/opt/rules.json", "Comma separated list of files to be used as input json")
 	target := flag.String("target", "/opt/rules.go", "Output file name that will be created with the generated Go code")
+	templDir := flag.String("templdir", "/app/templates", "Directory where the templates can be found")
 	condDebug := flag.Bool("condition-debug", false, "Whetever show output nodes with condition info for debugging")
 	flag.Parse()
 
@@ -200,7 +201,7 @@ func main() {
 	}
 
 	logrus.Debugf("Generating Go code")
-	sourceCode, err := executeTemplate("/app/templates", "main.tmpl", templateRulesMap)
+	sourceCode, err := executeTemplate(*templDir, "main.tmpl", templateRulesMap)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR adds an optional runtime parameter for the template dir: #16 . 

It keeps the default dir at `/app/templates`.

-----

As a corollary, this PR makes it explicit which runtime parameters one can provide for the `ruller-dsl-feature-flag`.