### PR TITLE
adds verification for the lazy_evaluation config and a recover method for runtime nil conversion panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,24 @@ curl -X POST \
   * [domains.json](https://github.com/flaviostutz/ruller-sample-feature-flag/blob/master/rules/domains.json)
   * [screens.json](https://github.com/flaviostutz/ruller-sample-feature-flag/blob/master/rules/screens.json)
 
+* You can also control some rule computation behaviors with the help of the `_config` key on your `.json` file. E.g.
+  ```json
+  {
+    "_config": {
+      "seed": 123,
+      "default_condition": true,
+      "lazy_evalutation": true,
+      "flatten": true
+    },
+    "_groups": [...],
+    "_items": [...]
+  }
+  ```
+  * `seed`: controls the pseudo-random generator seed in use. Everytime you change it, new random numbers will be assigned from you input;
+  * `default_condition`: tells which value should be returned when a rule have no condition assigned;
+  * `lazy_evaluation`: if set to `true`, for any missing input the resulting ruller return error on runtime and does not evaluate the rules, even those that have nothing to do with the missing input. The default value of this param is `false`, meaning the resulting ruller will evaluate all rules even though an input is missing;
+  * `flatten`: the output map will get flattened.
+
 ## Development tips
 
 * Always explicitly define the `target` and `templdir` runtime parameters on development time:
@@ -120,4 +138,5 @@ go build
   * Tag the repository code
   * Check the autobuild on Dockerhub to see if all went well and that the new tag was created
   * Update and test the example project https://github.com/flaviostutz/ruller-sample-feature-flag
+
 

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 		templateRule["_groupCodes"] = groupCodes
 
 		if lazyEvaluation {
-			// only validate required inputs if
+			// only validate required inputs if lazy evaluation mode is active
 			logrus.Debugf("REQUIRED INPUTS")
 			requiredInputCodes := make(map[string]string)
 			for in, it := range inputTypes {

--- a/templates/rule.tmpl
+++ b/templates/rule.tmpl
@@ -1,10 +1,10 @@
-
 	//RULE {{._ruleGroupName}}:{{._id}} (parent:{{._parentid}})
 {{if eq ._parentid "-1"}}
 	ruller.Add("{{._ruleGroupName}}", "{{._id}}", func(ctx ruller.Context) (map[string]interface{}, error) {
 {{else}}
 	ruller.AddChild("{{._ruleGroupName}}", "{{._id}}", "{{._parentid}}", func(ctx ruller.Context) (map[string]interface{}, error) {
 {{end}}
+		defer recoverNilAutoConversionError()
 		condition := {{._conditionCode}}
 		if condition {
 			output := make(map[string]interface{})

--- a/templates/utils.tmpl
+++ b/templates/utils.tmpl
@@ -113,7 +113,7 @@ func loadGroupArray(groups map[string]map[string]map[string]bool, ruleGroup stri
 func recoverNilAutoConversionError() {
 	if r := recover(); r != nil {
 		if strings.Contains(r.(error).Error(), "interface conversion: interface {} is nil") {
-			fmt.Println("Recovered in f", r)	
+			logrus.Debugf("Recovered ", r)	
 		} else {
 			panic(r.(error))
 		}

--- a/templates/utils.tmpl
+++ b/templates/utils.tmpl
@@ -109,3 +109,13 @@ func loadGroupArray(groups map[string]map[string]map[string]bool, ruleGroup stri
 		}
 	}
 }
+
+func recoverNilAutoConversionError() {
+	if r := recover(); r != nil {
+		if strings.Contains(r.(error).Error(), "interface conversion: interface {} is nil") {
+			fmt.Println("Recovered in f", r)	
+		} else {
+			panic(r.(error))
+		}
+	}
+}


### PR DESCRIPTION
Fix #12 

This PR adds the `lazy_evaluation` field config.

When `lazy_evaluation` field exists and is `true` (by default is `false`), the required input map is not filled.

That comes with the caveat that rules will be able to evaluate in runtime non-existent fields, and where type conversion happens (e.g. `ctx.Input["test"].(string)`), a `panic` will be thrown.

To overcome that, a `recoverNilAutoConversionError` func was created and a `defer` to that function has been added on every `Rule` evaluation.