### PR TITLE
adds glob pattern handling for the source param and example rules files

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ curl -X POST \
 
 * The same as http://github.com/flaviostutz/ruller with the addition of `--templdir`:
 
-1. `--source`: a comma-separated list of `.json` files where `ruller-dsl-feature-flag` will read the rules from;
+1. `--source`: a comma-separated list of Glob patterns or `.json` files where `ruller-dsl-feature-flag` will read the rules from. Attention: Glob patterns must be enclosed by double quotes on the command line;
 2. `--target`: the path of the file where the Golang ruller engine will be generated;
 3. `--templdir`: the path where the template files can be found;
 4. `--log-level`: the level of logging `ruller-dsl-feature-flag` will output to STDOUT;
@@ -107,7 +107,7 @@ curl -X POST \
   * [domains.json](https://github.com/flaviostutz/ruller-sample-feature-flag/blob/master/rules/domains.json)
   * [screens.json](https://github.com/flaviostutz/ruller-sample-feature-flag/blob/master/rules/screens.json)
 
-* You can also control some rule computation behaviors with the help of the `_config` key on your `.json` file. E.g.
+* You can also control some rule computation behaviors with the help of `_config` key on your `.json` file. E.g.
   ```json
   {
     "_config": {
@@ -127,11 +127,11 @@ curl -X POST \
 
 ## Development tips
 
-* Always explicitly define the `target` and `templdir` runtime parameters on development time:
+* Always explicitly define the `target` and `templdir` runtime parameters on development time. E.g.:
 
 ```sh
 go build
-./ruller-dsl-feature-flag --source <paths to rule json files> --target ./rules.go --templdir ./templates
+./ruller-dsl-feature-flag --source "example-rules/*.json" --target ./rules.go --templdir ./templates
 ```
 
 * After closing a version

--- a/example-rules/domains.json
+++ b/example-rules/domains.json
@@ -1,0 +1,51 @@
+{
+    "_config": {
+        "seed": 123,
+        "default_condition": true,
+        "flatten": true,
+        "keep_first": true
+    },
+    "_items": [{
+            "provider": "aws",
+            "_condition": "randomPerc(10, input:customerid)",
+            "_items": [{
+                    "region": "sa-east-1",
+                    "login": "login.sa-east-1.test.com",
+                    "bootcamp": "bootcamp.sa-east-1.test.com",
+                    "_condition": "input:_ip_country=='Brazil'"
+                },
+                {
+                    "region": "us-west-1",
+                    "login": "login.us-west-1.test.com",
+                    "events": "events.us-west-1.test.com",
+                    "bootcamp": "bootcamp.us-west-1.test.com"
+                }
+            ]
+        },
+        {
+            "provider": "azure",
+            "_condition": "randomPercRange(10, 50, input:customerid)",
+            "_items": [{
+                    "region": "azure-brazil",
+                    "login": "login.azure-brazil.test.com",
+                    "_condition": "input:_ip_country=='Brazil'"
+                },
+                {
+                    "region": "azure-ny",
+                    "login": "login.azure-ny.test.com",
+                    "events": "events.azure-ny.test.com",
+                    "bootcamp": "bootcamp.azure-ny.test.com"
+                }
+            ]
+        },
+        {
+            "provider": "vpsdime",
+            "_items": [{
+                "region": "vpsdime",
+                "login": "login.vpsdime.test.com",
+                "events": "events.azure-ny.test.com",
+                "bootcamp": "bootcamp.azure-ny.test.com"
+            }]
+        }
+    ]
+}

--- a/example-rules/menu.json
+++ b/example-rules/menu.json
@@ -1,0 +1,65 @@
+{
+    "label": "my root label",
+    "_config": {
+        "seed ": 123,
+        "default_condition": true
+    },
+    "_groups": {
+        "engineersid":["12","34","32","33","333","211"],
+        "customers1":"/groups/group1.txt"
+    },
+    "_items": [{
+            "label": "menu1",
+            "_items": [{
+                    "label": "menu1.1",
+                    "uri": "/menu1.1",
+                    "options": {
+                        "opt1": "123",
+                        "opt2": {
+                            "type": "simple",
+                            "qtty": 34
+                        }
+                    },
+                    "_condition": "true"
+                }, {
+                    "label": "menu1.2",
+                    "_condition": "input:age > 30 and randomPerc(30,input:customerid) or contains(group:engineersid,input:customerid)",
+                    "_items": [{
+                            "label": "menu1.2.1 "
+                        },
+                        {
+                            "label": "menu1.2.2",
+                            "_condition": "randomPerc(50,input:customerid)"
+                        }
+                    ]
+                }, {
+                    "label": "menu1.3",
+                    "_condition": "input:age > 30"
+                }, {
+                    "label": "menu1.4",
+                    "_condition": "randomPerc(30,input:customerid)"
+                }, {
+                    "label": "menu1.5",
+                    "_condition": "contains(group:engineersid,input:customerid)"
+                }, {
+                    "label": "menu1.6",
+                    "_condition": "contains(group:customers1,input:customerid)"
+                }
+            ]
+        },
+        {
+            "label": "menu2",
+            "_items": [{
+                    "label": "menu2.1",
+                    "_condition": "after('2018-11-30T23:32:21+00:00')"
+                }, {
+                    "label": "menu2.2",
+                    "_condition": "versionCheck(input:app_version, '>=1.3, <4.5')"
+                }, {
+                    "label": "menu2.3",
+                    "_condition": "input:_ip_state~='DF|RJ'"
+                }
+            ]
+        }
+    ]
+}

--- a/example-rules/screens.json
+++ b/example-rules/screens.json
@@ -1,0 +1,50 @@
+{
+    "label": "my root label",
+    "_config": {
+        "seed ": 123,
+        "default_condition": true
+    },
+    "_groups": {
+        "showtransfersscreen":["72373287","238823783","3232423","44444"],
+        "specialcustomers":"/groups/specialCustomers.txt"
+    },
+    "_items": [
+        {
+            "label": "redirect",
+            "_items": [
+                {
+                    "fromId":"paymentscreen",
+                    "targetId":"/tela/funcionalidade-indisponivel",
+                    "_condition": "input:_ip_city=='Brasília'"
+                },
+                {
+                    "fromId":"minhasfinancashome",
+                    "targetId":"minhasfinancashomeB",
+                    "_condition": "randomPerc(50, input:customerid)"
+                },
+                {
+                    "screenId":"minhasfinancashome",
+                    "targetId":"/tela/minhas-financas",
+                    "_condition": "versionCheck(input:app_version, '<=4.3')"
+                }
+            ]
+        },
+        {
+            "label": "hide",
+            "_items": [
+                {
+                    "screenId":"transferscreen",
+                    "_condition": "contains(group:showtransfersscreen,input:customerid)"
+                },
+                {
+                    "screenId":"accountscreen",
+                    "_condition": "before('2020-04-30T23:32:21+00:00')"
+                },
+                {
+                    "screenId":"specialcustomersscreen",
+                    "_condition": "randomPerc(10,input:customerid) and contains(group:specialcustomers,input:customerid)"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fix #22 

This PR adds Glob Pattern handling capabilities for the `source` param parsing.

Documentation has been updated to reflect these changes. 

Whenever a Glob pattern is used, it must be enclosed by double quotes, otherwise CLI params parsing by Go's `flag` lib can go haywire.